### PR TITLE
update: name to `oomd`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 
 .PHONY: bin
 bin: fmt vet
-	go build -o bin/oomlie github.com/jdockerty/kubectl-oomlie/cmd/plugin
+	go build -o bin/oomd github.com/jdockerty/kubectl-oomd/cmd/plugin
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# oomlie
+# oomd
 
 A `kubectl` plugin to display the pods and containers which have recently been `OOMKilled`.
 
@@ -6,7 +6,7 @@ A `kubectl` plugin to display the pods and containers which have recently been `
 
 Via [`krew`](https://krew.sigs.k8s.io/)
 ```
-kubectl krew install oomlie
+kubectl krew install oomd
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ This also shows the specific container which was killed too, helpful in the case
 
 
 ```
-kubectl oomlie
+kubectl oomd
 
 POD                         CONTAINER        TERMINATION TIME
 my-app-5bcbcdf97-722jp      infoapp          2022-11-04 10:51:48 +0000 GMT
@@ -27,7 +27,7 @@ my-app-5bcbcdf97-v9ff6      infoapp          2022-11-04 10:51:48 +0000 GMT
 You can specify another namespace, as you would with other `kubectl` commands.
 
 ```
-kubectl oomlie -n oomkilled
+kubectl oomd -n oomkilled
 
 POD                         CONTAINER        TERMINATION TIME
 my-app-5bcbcdf97-722jp      infoapp          2022-11-04 10:51:48 +0000 GMT
@@ -36,7 +36,7 @@ my-app-5bcbcdf97-v9ff6      infoapp          2022-11-04 10:51:48 +0000 GMT
 ```
 
 ```
-kubectl oomlie --no-headers
+kubectl oomd --no-headers
 
 my-app-5bcbcdf97-722jp      infoapp          2022-11-04 10:51:48 +0000 GMT
 my-app-5bcbcdf97-k52lg      infoapp          2022-11-04 10:51:48 +0000 GMT

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/jdockerty/kubectl-oomlie/pkg/logger"
-	"github.com/jdockerty/kubectl-oomlie/pkg/plugin"
+	"github.com/jdockerty/kubectl-oomd/pkg/logger"
+	"github.com/jdockerty/kubectl-oomd/pkg/plugin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -21,7 +21,7 @@ var (
 
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "kubectl oomlie",
+		Use:           "kubectl oomd",
 		Short:         "Show pods which have recently been OOMKilled",
 		Long:          `Show pods which have recently been terminated by Kubernetes due to an 'Out Of Memory' error`,
 		SilenceErrors: true,

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/jdockerty/kubectl-oomlie/cmd/plugin/cli"
+	"github.com/jdockerty/kubectl-oomd/cmd/plugin/cli"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // auth plugins
 )
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -3,13 +3,13 @@
 The following assumes you have the plugin installed via
 
 ```shell
-kubectl krew install oomlie
+kubectl krew install oomd
 ```
 
 Once installed, simply run 
 
 ```shell
-kubectl oomlie
+kubectl oomd
 ```
 
 This will display the pods which have been `OOMKilled`, if there are no pods which meet this requirement, then there will be no output.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jdockerty/kubectl-oomlie
+module github.com/jdockerty/kubectl-oomd
 
 go 1.16
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"fmt"
 
-	"github.com/jdockerty/kubectl-oomlie/pkg/logger"
+	"github.com/jdockerty/kubectl-oomd/pkg/logger"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"


### PR DESCRIPTION
Changing the project name from `oomlie` to `oom` as it is easier to index, remember, and use this way.
