### PR TITLE
chore: update `.krew.yaml` to templated version

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -12,7 +12,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_linux_amd64.tar.gz"" .TagName }}
+    {{addURIAndSha "https://github.com/jdockerty/kubectl-oomd/releases/download/{{ .TagName }}/oomd_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
     files:
     - from: "./oomd"
       to: "."
@@ -23,7 +23,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_darwin_amd64.tar.gz"" .TagName }}
+    {{addURIAndSha "https://github.com/jdockerty/kubectl-oomd/releases/download/{{ .TagName }}/oomd_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
     files:
     - from: "./oomd"
       to: "."
@@ -34,7 +34,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_windows_amd64.zip"" .TagName }}
+    {{addURIAndSha "https://github.com/jdockerty/kubectl-oomd/releases/download/{{ .TagName }}/oomd_{{ .TagName }}_windows_amd64.zip" .TagName }}
     files:
     - from: "/oomd.exe"
       to: "."

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -3,14 +3,13 @@ kind: Plugin
 metadata:
   name: oomd
 spec:
-  version: 'v0.0.2'
+  version: {{ .TagName }}
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: "https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_linux_amd64.tar.gz"
-    sha256: "d004aeba760503b4883ce7fed454962855d00bc4624c3c015704515a96e973dc"
+    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_linux_amd64.tar.gz"" .TagName }}
     files:
     - from: "./oomd"
       to: "."
@@ -21,8 +20,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: "https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_darwin_amd64.tar.gz"
-    sha256: "6f9baac1561b39ce694482e796c895e8c485d4ac0bbbe10cb39c1484df357117"
+    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_darwin_amd64.tar.gz"" .TagName }}
     files:
     - from: "./oomd"
       to: "."
@@ -33,8 +31,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: "https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_windows_amd64.zip"
-    sha256: "9a26d0651464f482da50c63927d337bd93904e15676400a88f793d3654910288"
+    {{addURIAndSha ""https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.2/oomd_windows_amd64.zip"" .TagName }}
     files:
     - from: "/oomd.exe"
       to: "."
@@ -46,3 +43,4 @@ spec:
   description: |
     Display pods and their corresponding containers which have recently
     been 'OOMKilled'
+

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,3 +1,6 @@
+# This is a templated file which is used by the krew-release-bot
+# from the GitHub Action to raise a pull request to the krew-index
+# (https://github.com/kubernetes-sigs/krew-index) with the correct tag
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -43,4 +43,3 @@ spec:
   description: |
     Display pods and their corresponding containers which have recently
     been 'OOMKilled'
-


### PR DESCRIPTION
The `krew-release-bot` provides a way to use a templated manifest which will raise the correct PR each time there is a new release of the plugin against the `krew-index` repository.
