### PR TITLE
feat: plugin version info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,8 +17,9 @@ builds:
       - CGO_ENABLED=0
       - GO111MODULE=on
     main: cmd/plugin/main.go
-    ldflags: -s -w
-      -X github.com/jdockerty/kubectl-oomd/pkg/version.version=
+    ldflags:
+      - -s -w -X github.com/jdockerty/kubectl-oomd/pkg/version.version={{ .Version }}
+      - -X github.com/jdockerty/kubectl-oomd/pkg/version.commit={{ .Commit }}
 archives:
   - id: oomd
     builds:

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/jdockerty/kubectl-oomd/pkg/plugin"
+	"github.com/jdockerty/kubectl-oomd/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -17,6 +18,7 @@ var (
 	KubernetesConfigFlags *genericclioptions.ConfigFlags
 	noHeaders             bool
 	allNamespaces         bool
+	showVersion           bool
 
 	// When using the namespace provided by the `--namespace/-n` flag or current context.
 	// This represents: Pod, Container, Request, Limit, and Termination Time
@@ -38,6 +40,12 @@ func RootCmd() *cobra.Command {
 			viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if showVersion {
+				versionInfo := version.GetVersion()
+				fmt.Printf("%s", versionInfo.ToString())
+				return nil
+			}
 
 			namespace := *KubernetesConfigFlags.Namespace
 			t := tabwriter.NewWriter(os.Stdout, 10, 1, 5, ' ', 0) // Formatting for table output, similar to other kubectl commands.
@@ -79,6 +87,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Don't print headers")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show OOMKilled containers across all namespaces")
+	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version information")
 	KubernetesConfigFlags = genericclioptions.NewConfigFlags(true)
 	KubernetesConfigFlags.AddFlags(cmd.Flags())
 

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -87,7 +87,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Don't print headers")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show OOMKilled containers across all namespaces")
-	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version information")
+	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version and build information")
 	KubernetesConfigFlags = genericclioptions.NewConfigFlags(true)
 	KubernetesConfigFlags.AddFlags(cmd.Flags())
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,6 +28,7 @@ type Version struct {
 	Version   string
 }
 
+// ToString populates the version/build information into the output template and returns it for use.
 func (v *Version) ToString() string {
 	return fmt.Sprintf(outputTemplate, v.Version, v.Commit, v.Platform, v.GoVersion)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,7 +19,8 @@ Go: %s
 )
 
 // Version contains all of the information about the build of the current release.
-// It is expected that this is ran on tagged releases and populated by `-ldfags` of the `go build` commmand.
+// It is expected that this is ran on tagged releases and populated by `-ldflags` of the `go build` commmand.
+// See the .gorelease.yml ldflags section for details.
 type Version struct {
 	Commit    string
 	GoVersion string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,8 @@ var (
 Version: %s
 Commit: %s
 Platform: %s
-Go: %s`
+Go: %s
+`
 )
 
 // Version contains all of the information about the build of the current release.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,41 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	commit   string
+	version  = "dev"
+	platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	outputTemplate = `
+Version: %s
+Commit: %s
+Platform: %s
+Go: %s`
+)
+
+// Version contains all of the information about the build of the current release.
+// It is expected that this is ran on tagged releases and populated by `-ldfags` of the `go build` commmand.
+type Version struct {
+	Commit    string
+	GoVersion string
+	Platform  string
+	Version   string
+}
+
+func (v *Version) ToString() string {
+	return fmt.Sprintf(outputTemplate, v.Version, v.Commit, v.Platform, v.GoVersion)
+}
+
+// GetVersion is used to retrieve the current version information of the application.
+func GetVersion() *Version {
+	return &Version{
+		Commit:    commit,
+		GoVersion: runtime.Version(),
+		Platform:  platform,
+		Version:   version,
+	}
+}


### PR DESCRIPTION
Adds in some simple version information that can be used to debug/diagnose issues that may crop up later.

Example from local build using `goreleaser`

```
dist/oomd_linux_amd64_v1/oomd --version # -v also works

Version: 0.0.4-SNAPSHOT-c1b9a53
Commit: c1b9a5391a6a1f0bb3f62dbed1195a9dc9e1cacd
Platform: linux/amd64
Go: go1.18.7
```
