### PR TITLE
refactor: cleanup and efficiency

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -27,13 +27,16 @@ var (
 	// When using the `all-namespaces` flag, we must show which namespace the pod was in, this becomes an extra column.
 	// This represents: Namespace, Pod, Container, Request, Limit, and Termination Time
 	allNamespacesFormatting = "%s\t%s\t%s\t%s\t%s\t%s\n"
+
+	// Formatting for table output, similar to other kubectl commands.
+	t = tabwriter.NewWriter(os.Stdout, 10, 1, 5, ' ', 0)
 )
 
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "kubectl oomd",
-		Short:         "Show pods which have recently been OOMKilled",
-		Long:          `Show pods which have recently been terminated by Kubernetes due to an 'Out Of Memory' error`,
+		Short:         "Show pods/containers which have recently been OOMKilled",
+		Long:          `Show pods and containers which have recently been terminated by Kubernetes due to an 'Out Of Memory' error`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -16,9 +16,16 @@ import (
 
 var (
 	KubernetesConfigFlags *genericclioptions.ConfigFlags
-	noHeaders             bool
-	allNamespaces         bool
-	showVersion           bool
+
+	// Provides the `--no-headers` flag, this removes them from being printed to stdout.
+	noHeaders bool
+
+	// Provides the `--all-namespaces` or `-A` flag which iterates over all namespaces
+	// and adds an extra 'NAMESPACE' header to the output.
+	allNamespaces bool
+
+	// Provides the `--version` or `-v` flag, displaying build/version information.
+	showVersion bool
 
 	// When using the namespace provided by the `--namespace/-n` flag or current context.
 	// This represents: Pod, Container, Request, Limit, and Termination Time

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -51,21 +51,27 @@ func RootCmd() *cobra.Command {
 			}
 
 			namespace := *KubernetesConfigFlags.Namespace
-			t := tabwriter.NewWriter(os.Stdout, 10, 1, 5, ' ', 0) // Formatting for table output, similar to other kubectl commands.
 
 			oomPods, err := plugin.Run(KubernetesConfigFlags, allNamespaces, namespace)
 			if err != nil {
 				return errors.Unwrap(err)
 			}
 
-			// All namespaces flag requires an extra 'NAMESPACE' heading
+			// All namespaces flag requires the extra 'NAMESPACE' heading
 			if allNamespaces {
 				if !noHeaders {
-					fmt.Fprintf(t, allNamespacesFormatting, "NAMESPACE", "POD", "CONTAINER", "REQUEST", "LIMIT", "TERMINATION TIME")
+					_, err := fmt.Fprintf(t, allNamespacesFormatting, "NAMESPACE", "POD", "CONTAINER", "REQUEST", "LIMIT", "TERMINATION TIME")
+					if err != nil {
+						return err
+					}
 				}
 
 				for _, p := range oomPods {
-					fmt.Fprintf(t, allNamespacesFormatting, p.Pod.Namespace, p.Pod.Name, p.ContainerName, p.Memory.Request, p.Memory.Limit, p.TerminatedTime)
+					_, err := fmt.Fprintf(t, allNamespacesFormatting, p.Pod.Namespace, p.Pod.Name, p.ContainerName, p.Memory.Request, p.Memory.Limit, p.TerminatedTime)
+					if err != nil {
+						return err
+					}
+
 				}
 
 				t.Flush()
@@ -73,11 +79,17 @@ func RootCmd() *cobra.Command {
 			}
 
 			if !noHeaders {
-				fmt.Fprintf(t, singleNamespaceFormatting, "POD", "CONTAINER", "REQUEST", "LIMIT", "TERMINATION TIME")
+				_, err := fmt.Fprintf(t, singleNamespaceFormatting, "POD", "CONTAINER", "REQUEST", "LIMIT", "TERMINATION TIME")
+				if err != nil {
+					return err
+				}
 			}
 
 			for _, p := range oomPods {
-				fmt.Fprintf(t, singleNamespaceFormatting, p.Pod.Name, p.ContainerName, p.Memory.Request, p.Memory.Limit, p.TerminatedTime)
+				_, err := fmt.Fprintf(t, singleNamespaceFormatting, p.Pod.Name, p.ContainerName, p.Memory.Request, p.Memory.Limit, p.TerminatedTime)
+				if err != nil {
+					return err
+				}
 			}
 
 			t.Flush()

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -60,6 +60,7 @@ func RootCmd() *cobra.Command {
 				return nil
 			}
 
+			// The namespace provided to the flag takes precedence.
 			namespace := *KubernetesConfigFlags.Namespace
 
 			oomPods, err := plugin.Run(KubernetesConfigFlags, allNamespaces, namespace)
@@ -67,7 +68,7 @@ func RootCmd() *cobra.Command {
 				return errors.Unwrap(err)
 			}
 
-			// All namespaces flag requires the extra 'NAMESPACE' heading
+			// All namespaces flag requires the extra 'NAMESPACE' heading.
 			if allNamespaces {
 				if !noHeaders {
 					_, err := fmt.Fprintf(t, allNamespacesFormatting, "NAMESPACE", "POD", "CONTAINER", "REQUEST", "LIMIT", "TERMINATION TIME")

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -15,6 +15,9 @@ import (
 )
 
 var (
+
+	// KubernetesConfigFlags provides the generic flags which are available to
+	// regular `kubectl` commands, such as `--context` and `--namespace`.
 	KubernetesConfigFlags *genericclioptions.ConfigFlags
 
 	// Provides the `--no-headers` flag, this removes them from being printed to stdout.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -109,7 +109,7 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) ([]
 	return terminatedPodsInfo, nil
 }
 
-// Runreturns the pod information for those that have been OOMKilled, this provides the plugin functionality.
+// Run returns the pod information for those that have been OOMKilled, this provides the plugin functionality.
 func Run(configFlags *genericclioptions.ConfigFlags, allNamespaces bool, providedNamespace string) ([]TerminatedPodInfo, error) {
 	config, err := configFlags.ToRESTConfig()
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -76,17 +76,17 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) ([]
 
 	for _, pod := range terminatedPods {
 
-		for containerIndex, containerStatus := range pod.Status.ContainerStatuses {
+		for i, containerStatus := range pod.Status.ContainerStatuses {
 
 			// Not every container within the pod will be in a terminated state, we skip these ones.
-			// This also means we can use the 'containerIndex' to directly access the correct container,
+			// This also means we can use the relevant index to directly access the container,
 			// as we know its index within the container status list.
 			if containerStatus.LastTerminationState.Terminated == nil {
 				continue
 			}
 
-			startTime := pod.Status.ContainerStatuses[containerIndex].LastTerminationState.Terminated.StartedAt.String()
-			terminatedTime := pod.Status.ContainerStatuses[containerIndex].LastTerminationState.Terminated.FinishedAt.String()
+			startTime := pod.Status.ContainerStatuses[i].LastTerminationState.Terminated.StartedAt.String()
+			terminatedTime := pod.Status.ContainerStatuses[i].LastTerminationState.Terminated.FinishedAt.String()
 
 			// Build our terminated pod info struct
 			info := TerminatedPodInfo{
@@ -95,8 +95,8 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) ([]
 				StartTime:      startTime,
 				TerminatedTime: terminatedTime,
 				Memory: MemoryInfo{
-					Limit:   pod.Spec.Containers[containerIndex].Resources.Limits.Memory().String(),
-					Request: pod.Spec.Containers[containerIndex].Resources.Requests.Memory().String(),
+					Limit:   pod.Spec.Containers[i].Resources.Limits.Memory().String(),
+					Request: pod.Spec.Containers[i].Resources.Requests.Memory().String(),
 				},
 			}
 


### PR DESCRIPTION
General pass over for ensuring docstrings are correct and the application layout is clear/easy to follow - this can also include renaming functions or trimming/splitting them too.
