### PR TITLE
feat: no oomkilled pods msg

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -61,9 +61,14 @@ func RootCmd() *cobra.Command {
 			}
 
 			// The namespace provided to the flag takes precedence.
-			namespace := *KubernetesConfigFlags.Namespace
+			ns := *KubernetesConfigFlags.Namespace
 
-			oomPods, err := plugin.Run(KubernetesConfigFlags, allNamespaces, namespace)
+			namespace, err := plugin.GetNamespace(KubernetesConfigFlags, allNamespaces, ns)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve namespace, got %s: %w", ns, err)
+			}
+
+			oomPods, err := plugin.Run(KubernetesConfigFlags, namespace)
 			if err != nil {
 				return errors.Unwrap(err)
 			}

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -73,6 +73,7 @@ func RootCmd() *cobra.Command {
 				return errors.Unwrap(err)
 			}
 
+			// Handle no pods/containers found in a similar fashion to `kubectl`
 			if len(oomPods) == 0 {
 				if allNamespaces {
 					fmt.Println("No out of memory pods found.")

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -73,6 +73,15 @@ func RootCmd() *cobra.Command {
 				return errors.Unwrap(err)
 			}
 
+			if len(oomPods) == 0 {
+				if allNamespaces {
+					fmt.Println("No out of memory pods found.")
+					return nil
+				}
+				fmt.Printf("No out of memory pods found in %s namespace.\n", namespace)
+				return nil
+			}
+
 			// All namespaces flag requires the extra 'NAMESPACE' heading.
 			if allNamespaces {
 				if !noHeaders {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -110,7 +110,7 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) ([]
 }
 
 // Run returns the pod information for those that have been OOMKilled, this provides the plugin functionality.
-func Run(configFlags *genericclioptions.ConfigFlags, allNamespaces bool, providedNamespace string) ([]TerminatedPodInfo, error) {
+func Run(configFlags *genericclioptions.ConfigFlags, namespace string) ([]TerminatedPodInfo, error) {
 	config, err := configFlags.ToRESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kubeconfig: %w", err)
@@ -119,11 +119,6 @@ func Run(configFlags *genericclioptions.ConfigFlags, allNamespaces bool, provide
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
-	}
-
-	namespace, err := GetNamespace(configFlags, allNamespaces, providedNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve namespace, got %s: %w", providedNamespace, err)
 	}
 
 	terminatedPods, err := BuildTerminatedPodsInfo(clientset, namespace)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,7 +25,8 @@ type MemoryInfo struct {
 	Limit   string
 }
 
-// GetNamespace will retrieve the current namespace from the provided namespace or kubeconfig file of the caller.
+// GetNamespace will retrieve the current namespace from the provided namespace or kubeconfig file of the caller
+// or handle the return of the all namespaces shortcut when the flag is set.
 func GetNamespace(configFlags *genericclioptions.ConfigFlags, all bool, givenNamespace string) (string, error) {
 
 	if givenNamespace == "" && all {


### PR DESCRIPTION
Alter the output depending on whether there were any `OOMKilled` pods found or not.

This is handled in a similar manner to `kubectl`.
