### PR TITLE
feat: sort by termination timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ my-app-5bcbcdf97-k8g8g     infoapp          1G          8G        2022-11-07 14:
 my-app-5bcbcdf97-mf65j     infoapp          1G          8G        2022-11-07 14:34:57 +0000 GMT
 ```
 
+Experimental sorting is enabled through the `--sort-field` flag. By default, this is `none`.
+At the moment, only `time` is supported which sorts by termination time of containers, this is mainly
+useful in larger outputs across all namespaces (`-A`), used in conjunction with a pipe to `tail`.
+A simple example of this in action is shown below.
+
+```
+# The default with no sorting.
+kubectl oomd -n tracing
+POD                    CONTAINER        REQUEST     LIMIT     TERMINATION TIME
+jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:31 +0000 GMT
+jaeger-agent-j5vb8     jaeger-agent     100Mi       100Mi     2022-11-09 23:20:38 +0000 GMT
+
+# Most recently OOMKilled pods are shown first
+kubectl oomd -n tracing --sort-field time
+POD                    CONTAINER        REQUEST     LIMIT     TERMINATION TIME
+jaeger-agent-j5vb8     jaeger-agent     100Mi       100Mi     2022-11-09 23:20:38 +0000 GMT
+jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:31 +0000 GMT
+```
+
 ### Development
 
 If you wish to force some `OOMKilled` for testing purposes, you can use [`oomer`](https://github.com/jdockerty/oomer)

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -145,7 +145,7 @@ func RootCmd() *cobra.Command {
 
 	cobra.OnInitialize(initConfig)
 
-	cmd.Flags().StringVar(&sortField, "sort-field", "", "Sort by particular field. (Only 'termination_time' is supported currently)")
+	cmd.Flags().StringVar(&sortField, "sort-field", "", "Sort by particular field. (Only 'time' is supported currently)")
 	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Don't print headers")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show OOMKilled containers across all namespaces")
 	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version and build information")

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -30,6 +30,10 @@ var (
 	// Provides the `--version` or `-v` flag, displaying build/version information.
 	showVersion bool
 
+	// Provides the `--sort-field` flag, allowing sorting by field.
+	// Only 'time' is supported currently.
+	sortField string
+
 	// When using the namespace provided by the `--namespace/-n` flag or current context.
 	// This represents: Pod, Container, Request, Limit, and Termination Time
 	singleNamespaceFormatting = "%s\t%s\t%s\t%s\t%s\n"
@@ -40,6 +44,11 @@ var (
 
 	// Formatting for table output, similar to other kubectl commands.
 	t = tabwriter.NewWriter(os.Stdout, 10, 1, 5, ' ', 0)
+)
+
+const (
+	// Sort by termination timestamp in ascending order.
+	sortFieldTerminationTime = "time"
 )
 
 func RootCmd() *cobra.Command {
@@ -81,6 +90,10 @@ func RootCmd() *cobra.Command {
 				}
 				fmt.Printf("No out of memory pods found in %s namespace.\n", namespace)
 				return nil
+			}
+
+			if sortField == sortFieldTerminationTime {
+				oomPods.SortByTimestamp()
 			}
 
 			// All namespaces flag requires the extra 'NAMESPACE' heading.
@@ -126,6 +139,7 @@ func RootCmd() *cobra.Command {
 
 	cobra.OnInitialize(initConfig)
 
+	cmd.Flags().StringVar(&sortField, "sort-field", "", "Sort by particular field. (Only 'termination_time' is supported currently)")
 	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Don't print headers")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show OOMKilled containers across all namespaces")
 	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version and build information")

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -47,6 +47,10 @@ var (
 )
 
 const (
+	// Do not use any sorting, this is the default and acts as a value used
+	// in order to catch other values that are passed which are unsupported.
+	sortFieldDefault = "none"
+
 	// Sort by termination timestamp in ascending order.
 	sortFieldTerminationTime = "time"
 )
@@ -99,7 +103,9 @@ func RootCmd() *cobra.Command {
 			switch sortField {
 			case sortFieldTerminationTime:
 				oomPods.SortByTimestamp()
+			case sortFieldDefault:
 			default:
+				return fmt.Errorf("%s is not a supported sortable field.", sortField)
 			}
 
 			// All namespaces flag requires the extra 'NAMESPACE' heading.
@@ -145,7 +151,7 @@ func RootCmd() *cobra.Command {
 
 	cobra.OnInitialize(initConfig)
 
-	cmd.Flags().StringVar(&sortField, "sort-field", "", "Sort by particular field. (Only 'time' is supported currently)")
+	cmd.Flags().StringVar(&sortField, "sort-field", "none", "Sort by particular field. (Only 'time' is supported currently)")
 	cmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Don't print headers")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show OOMKilled containers across all namespaces")
 	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Display version and build information")

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -92,8 +92,12 @@ func RootCmd() *cobra.Command {
 				return nil
 			}
 
-			if sortField == sortFieldTerminationTime {
+			// Mutate our pods slice in-place depending on the sort-field flag
+			// that is used. The default is to do nothing.
+			switch sortField {
+			case sortFieldTerminationTime:
 				oomPods.SortByTimestamp()
+			default:
 			}
 
 			// All namespaces flag requires the extra 'NAMESPACE' heading.

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -93,7 +93,9 @@ func RootCmd() *cobra.Command {
 			}
 
 			// Mutate our pods slice in-place depending on the sort-field flag
-			// that is used. The default is to do nothing.
+			// that is used. The default is to do nothing to the slice; coincidentally
+			// this does sort by container name, or namespace if `--all-namespaces`
+			// flag is used.
 			switch sortField {
 			case sortFieldTerminationTime:
 				oomPods.SortByTimestamp()

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -48,7 +48,7 @@ var (
 
 const (
 	// Do not use any sorting, this is the default and acts as a value used
-	// in order to catch other values that are passed which are unsupported.
+	// to catch other arguments that are passed in which are unsupported.
 	sortFieldDefault = "none"
 
 	// Sort by termination timestamp in ascending order.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"fmt"
+	"sort"
+	"time"
 
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
@@ -10,6 +12,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// TerminatedPods is a wrapper type around multiple TerminatedPodInfo structs.
+type TerminatedPods []TerminatedPodInfo
+
+// SortByTimestamp sorts the terminated pods slice in descending order, in other
+// words, it shows the first OOMKilled pod found at the top of the table and the
+// most recent on at the end.
+func (t TerminatedPods) SortByTimestamp() {
+	sort.Slice(t, func(i, j int) bool {
+		return t[i].terminatedTime.After(t[j].terminatedTime)
+	})
+}
 
 // TerminatedPodInfo is a wrapper struct around an OOMKilled Pod's information.
 type TerminatedPodInfo struct {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -16,12 +16,12 @@ import (
 // TerminatedPods is a wrapper type around multiple TerminatedPodInfo structs.
 type TerminatedPods []TerminatedPodInfo
 
-// SortByTimestamp sorts the terminated pods slice in descending order, in other
+// SortByTimestamp sorts the terminated pods slice in ascending order, in other
 // words, it shows the first OOMKilled pod found at the top of the table and the
-// most recent on at the end.
+// most recent one at the end.
 func (t TerminatedPods) SortByTimestamp() {
 	sort.Slice(t, func(i, j int) bool {
-		return t[i].terminatedTime.After(t[j].terminatedTime)
+		return t[i].terminatedTime.Before(t[j].terminatedTime)
 	})
 }
 
@@ -146,7 +146,7 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) (Te
 }
 
 // Run returns the pod information for those that have been OOMKilled, this provides the plugin functionality.
-func Run(configFlags *genericclioptions.ConfigFlags, namespace string) ([]TerminatedPodInfo, error) {
+func Run(configFlags *genericclioptions.ConfigFlags, namespace string) (TerminatedPods, error) {
 
 	clientset, _, err := getK8sClientAndConfig(configFlags)
 	if err != nil {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -145,3 +145,33 @@ func TestFilterTerminatedPods(t *testing.T) {
 	assert.Equal(t, "oomedPod", oomed[0].Name)
 
 }
+
+func TestSortByTimestamp(t *testing.T) {
+
+	now := time.Now()
+
+	times := map[string]time.Time{
+		"now": now,
+		"1d":  now.AddDate(0, 0, 1),
+		"2d":  now.AddDate(0, 0, 2),
+		"1mo": now.AddDate(0, 1, 0),
+	}
+
+	// These are not in the descending order
+	tests := TerminatedPods{
+		TerminatedPodInfo{ContainerName: "1 month", terminatedTime: times["1mo"]},
+		TerminatedPodInfo{ContainerName: "now", terminatedTime: times["now"]},
+		TerminatedPodInfo{ContainerName: "2 days", terminatedTime: times["2d"]},
+		TerminatedPodInfo{ContainerName: "1 day", terminatedTime: times["1d"]},
+	}
+
+	tests.SortByTimestamp()
+
+	assert.Equal(t, tests[0].ContainerName, "1 month")
+	assert.Equal(t, tests[1].ContainerName, "2 days")
+	assert.Equal(t, tests[2].ContainerName, "1 day")
+	assert.Equal(t, tests[3].ContainerName, "now")
+
+	t.Log("Pods are in descending order.")
+
+}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -167,10 +167,10 @@ func TestSortByTimestamp(t *testing.T) {
 
 	tests.SortByTimestamp()
 
-	assert.Equal(t, tests[0].ContainerName, "1 month")
-	assert.Equal(t, tests[1].ContainerName, "2 days")
-	assert.Equal(t, tests[2].ContainerName, "1 day")
-	assert.Equal(t, tests[3].ContainerName, "now")
+	assert.Equal(t, tests[0].ContainerName, "now")
+	assert.Equal(t, tests[1].ContainerName, "1 day")
+	assert.Equal(t, tests[2].ContainerName, "2 days")
+	assert.Equal(t, tests[3].ContainerName, "1 month")
 
 	t.Log("Pods are in descending order.")
 


### PR DESCRIPTION
Add functionality to sort by termination timestamp, this is in descending order, i.e. the pods recent `OOMKilled` pod will show at the bottom of the table.

_This example will be used in the `README.md` file_

```
# The default with no sorting.
kubectl oomd -n tracing
POD                    CONTAINER        REQUEST     LIMIT     TERMINATION TIME
jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:31 +0000 GMT
jaeger-agent-j5vb8     jaeger-agent     100Mi       100Mi     2022-11-09 23:20:38 +0000 GMT

# Most recently OOMKilled pods are shown first
kubectl oomd -n tracing --sort-field time
POD                    CONTAINER        REQUEST     LIMIT     TERMINATION TIME
jaeger-agent-j5vb8     jaeger-agent     100Mi       100Mi     2022-11-09 23:20:38 +0000 GMT
jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:31 +0000 GMT
```