### PR TITLE
release: 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Or manually from the [releases](https://github.com/jdockerty/kubectl-oomd/releas
 
 ```shell
 # Download the release for your OS
-wget https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.6/oomd_linux_amd64.tar.gz
+wget https://github.com/jdockerty/kubectl-oomd/releases/download/v0.0.7/oomd_linux_amd64.tar.gz
 
 # Extract files from the archive
 tar -xvf oomd_linux_amd64.tar.gz


### PR DESCRIPTION
Prep for 0.0.7 release

Closes https://github.com/jdockerty/kubectl-oomd/issues/20

---

- https://github.com/jdockerty/kubectl-oomd/commit/1ab0cefff8791ab19366684aedd5e6c9a6226244 Fixes a bug raised in https://github.com/jdockerty/kubectl-oomd/issues/20 for mismatching memory requests/limits with large multi-container pods.
- https://github.com/jdockerty/kubectl-oomd/commit/f353d1c9a9f5b5fd0d4039d71e6a79041621cb40 Adds the `--sort-field` flag to sort by termination timestamp, currently only `--sort-field time` is supported.