### PR TITLE
fix: request/limits mismatch with many containers in a pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:3
 
 ### Development
 
-If you wish to force some `OOMKilled` for testing purposes, you can use [`oomer`](https://github.com/jdockerty/oomer)
+If you wish to force some `OOMKilled` pods for testing purposes, you can use [`oomer`](https://github.com/jdockerty/oomer)
 or simply run
 
     kubectl apply -f https://raw.githubusercontent.com/jdockerty/oomer/main/oomer.yaml

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ jaeger-agent-4k845     jaeger-agent     100Mi       100Mi     2022-11-11 21:06:3
 If you wish to force some `OOMKilled` for testing purposes, you can use [`oomer`](https://github.com/jdockerty/oomer)
 or simply run
 
-    kubectl apply -f https://github.com/jdockerty/oomer/blob/main/oomer.yaml
+    kubectl apply -f https://raw.githubusercontent.com/jdockerty/oomer/main/oomer.yaml
 
 This will create the `oomkilled` namespace and a `Deployment` with pods that continually exit with code `137`,
 in order to be picked up by `oomd`.

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -34,7 +34,6 @@ var (
 	// Only 'time' is supported currently.
 	sortField string
 
-
 	// Formatting for table output, similar to other kubectl commands.
 	t = tabwriter.NewWriter(os.Stdout, 10, 1, 5, ' ', 0)
 )

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -124,7 +124,7 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) (Te
 	terminatedPods := TerminatedPodsFilter(pods.Items)
 
 	for _, pod := range terminatedPods {
-		for i, containerStatus := range pod.Status.ContainerStatuses {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
 
 			// Not every container within the pod will be in a terminated state, we skip these ones.
 			// This also means we can use the relevant index to directly access the container,
@@ -133,8 +133,8 @@ func BuildTerminatedPodsInfo(client *kubernetes.Clientset, namespace string) (Te
 				continue
 			}
 
-			containerStartTime := pod.Status.ContainerStatuses[i].LastTerminationState.Terminated.StartedAt.String()
-			containerTerminatedTime := pod.Status.ContainerStatuses[i].LastTerminationState.Terminated.FinishedAt
+			containerStartTime := containerStatus.LastTerminationState.Terminated.StartedAt.String()
+			containerTerminatedTime := containerStatus.LastTerminationState.Terminated.FinishedAt
 
 			podSpecIndex, err := getPodSpecIndex(containerStatus.Name, pod)
 			if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -60,9 +60,9 @@ func getK8sClientAndConfig(configFlags *genericclioptions.ConfigFlags) (*kuberne
 }
 
 // getPodSpecIndex is a helper function to return the index of a container
-// within the `.spec.containers` of a Pod. This is used as the index that
-// it appears within the containerStatus field is not guaranteed to be
-// the same.
+// within the containers list of the pod specification. This is used as the
+// index, as the index which appears within the containerStatus field is not
+// guaranteed to be the same.
 func getPodSpecIndex(name string, pod v1.Pod) (int, error) {
 
 	for i, c := range pod.Spec.Containers {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -129,7 +129,7 @@ func (rc *RequiresClusterTests) TestCorrectResources() {
 	defer res.Body.Close()
 
 	// We can pass containerIndex 0 here as I control the manifest we are using, so it is
-	// okay to hardcode it.
+	// okay to hardcode it, since I know it is the first index.
 	manifestReq, manifestLim, err := getMemoryRequestAndLimitFromDeploymentManifest(res.Body, 0)
 	assert.Nil(rc.T(), err) // We don't skip this on failure, as if we got the manifest it should be a Deployment.
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -132,14 +132,15 @@ func (rc *RequiresClusterTests) TestCorrectResources() {
 
 	// We can pass containerIndex 0 here as I control the manifest we are using, so it is
 	// okay to hardcode it, since I know it is the first index.
-	manifestReq, manifestLim, err := getMemoryRequestAndLimitFromDeploymentManifest(res.Body, 0)
+	knownIndex := 0
+	manifestReq, manifestLim, err := getMemoryRequestAndLimitFromDeploymentManifest(res.Body, knownIndex)
 	assert.Nil(rc.T(), err) // We don't skip this on failure, as if we got the manifest it should be a Deployment.
 
 	pods, _ := Run(KubernetesConfigFlags, rc.IntegrationTestNamespace)
 
 	fmt.Println(manifestReq, manifestLim)
-	podMemoryRequest := pods[0].Pod.Spec.Containers[0].Resources.Requests["memory"]
-	podMemoryLimit := pods[0].Pod.Spec.Containers[0].Resources.Limits["memory"]
+	podMemoryRequest := pods[knownIndex].Pod.Spec.Containers[knownIndex].Resources.Requests["memory"]
+	podMemoryLimit := pods[knownIndex].Pod.Spec.Containers[knownIndex].Resources.Limits["memory"]
 
 	assert.Equal(rc.T(), podMemoryRequest.String(), manifestReq)
 	assert.Equal(rc.T(), podMemoryLimit.String(), manifestLim)

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -105,6 +105,8 @@ func (rc *RequiresClusterTests) SetupSuite() {
 	time.Sleep(30 * time.Second)
 }
 
+// TearDownSuite runs the deletion process against the Namespace and Deployment
+// created as part of the testing process.
 func (rc *RequiresClusterTests) TearDownSuite() {
 	applyOrDeleteOOMKilledManifest(true)
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -76,6 +76,14 @@ func (rc *RequiresClusterTests) TestRunPlugin() {
 	assert.Greater(rc.T(), len(pods), 0, "expected number of failed pods to be greater than 0, got %d", len(pods))
 }
 
+// TODO: Read YAML stream from forceOOMKilledManifest and compare memory request/limit
+//func (rc *RequiresClusterTests) TestCorrectResources() {
+//	pods, err := Run(KubernetesConfigFlags, rc.IntegrationTestNamespace)
+//	assert.Nil(rc.T(), err)
+//
+//	assert.Greater(rc.T(), len(pods), 0, "expected number of failed pods to be greater than 0, got %d", len(pods))
+//}
+
 func TestRequiresClusterSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("skipping %s which requires running cluster", t.Name())


### PR DESCRIPTION
Relates to https://github.com/jdockerty/kubectl-oomd/issues/20

The mismatch here occurs from the use of the incorrect index when building the `TerminatedPodInfo` struct within the loop from the `BuildTerminatedPodsInfo` func.

```go
for _, pod := range terminatedPods {

	for i, containerStatus := range pod.Status.ContainerStatuses {

		// Build our terminated pod info struct
		info := TerminatedPodInfo{
                ...
			Memory: MemoryInfo{
			Limit:   pod.Spec.Containers[i].Resources.Limits.Memory().String(),
			Request: pod.Spec.Containers[i].Resources.Requests.Memory().String(),
			},
		}
	terminatedPodsInfo = append(terminatedPodsInfo, info)
	}
}
// etc...
```

This makes the output incorrect too, e.g.

```
POD                        CONTAINER         REQUEST     LIMIT     TERMINATION TIME
oomer-57874f78f8-zn4wn     oomer-100-100     128Mi       128Mi     2022-12-08 17:36:47 +0000 GMT
oomer-57874f78f8-zn4wn     oomer-100-200     50Mi        50Mi      2022-12-08 17:37:12 +0000 GMT
oomer-57874f78f8-zn4wn     oomer-128-128     100Mi       100Mi     2022-12-08 17:36:27 +0000 GMT
```

In the above table, the container name is in the format of `NAME-REQUEST-LIMIT`, so that it can be easily seen that there is a mismatch.

This is a logical reasoning error as the index (`i`) within the `containerStatuses` inner loop is not always the same as the container which is presented in the `pod.Spec.Containers`, causing a mismatch in the memory limits/requests.

I don't believe this presents itself as a problem when there are only 1-2 containers, because of the ordering within the status field.

---

To fix this issue the current pod is matched with the correct index from the Pod specification, using the `getPodSpecIndex` function.

https://github.com/jdockerty/kubectl-oomd/blob/1326001dd0c4f5cfc3344e393e78e6fe11446786/pkg/plugin/plugin.go#L139

https://github.com/jdockerty/kubectl-oomd/blob/1326001dd0c4f5cfc3344e393e78e6fe11446786/pkg/plugin/plugin.go#L152-L153